### PR TITLE
double-fuzzy lets rsync check link-dest dir

### DIFF
--- a/turku_storage/ping.py
+++ b/turku_storage/ping.py
@@ -254,6 +254,8 @@ class StoragePing:
                     rsync_args.append(
                         "--link-dest=%s" % os.path.join(snapshot_dir, base_snapshot)
                     )
+                    # repeat the option so that rsync looks into the dir specified in link-dest, see rsync(1)
+                    rsync_args.extend(["--fuzzy", "--fuzzy"])
             else:
                 rsync_args.append("--inplace")
             if self.config["preserve_hard_links"]:


### PR DESCRIPTION
When using `--link-dest`, add `--fuzzy`, twice so that rsync checks for possible matches in the directory specified by `--link-dest`
