### PR TITLE
Include environment name and write out metadata file

### DIFF
--- a/turku_storage/ping.py
+++ b/turku_storage/ping.py
@@ -220,17 +220,24 @@ class StoragePing:
                 os.makedirs(machine_dir)
 
             machine_symlink = machine["unit_name"]
+            meta = ["unit_name: %s" % (machine['unit_name'])]
             if "service_name" in machine and machine["service_name"]:
                 machine_symlink = machine["service_name"] + "-" + machine_symlink
+                meta.append("service_name: %s" % (machine['service_name']))
             if "environment_name" in machine and machine["environment_name"]:
                 machine_symlink = machine["environment_name"] + "-" + machine_symlink
+                meta.append("environment_name: %s" % (machine['environment_name']))
             machine_symlink = machine_symlink.replace("/", "_")
             if os.path.islink(os.path.join(var_machines, machine_symlink)):
                 os.unlink(os.path.join(var_machines, machine_symlink))
             if not os.path.exists(os.path.join(var_machines, machine_symlink)):
                 os.symlink(machine["uuid"], os.path.join(var_machines, machine_symlink))
 
-            self.logger.info("Begin: %s %s" % (machine["unit_name"], source_name))
+            meta_path = os.path.join(machine_dir, ".turku-storage-metadata.txt")
+            with open(meta_path, "w") as f:
+                f.write("\n".join(meta) + "\n")
+
+            self.logger.info("Begin: %s %s (%s)" % (machine["unit_name"], source_name, machine.get("environment_name")))
 
             rsync_args = [
                 "rsync",

--- a/turku_storage/ping.py
+++ b/turku_storage/ping.py
@@ -233,10 +233,6 @@ class StoragePing:
             if not os.path.exists(os.path.join(var_machines, machine_symlink)):
                 os.symlink(machine["uuid"], os.path.join(var_machines, machine_symlink))
 
-            meta_path = os.path.join(machine_dir, ".turku-storage-metadata.txt")
-            with open(meta_path, "w") as f:
-                f.write("\n".join(meta) + "\n")
-
             self.logger.info("Begin: %s %s (%s)" % (machine["unit_name"], source_name, machine.get("environment_name")))
 
             rsync_args = [
@@ -308,6 +304,7 @@ class StoragePing:
             snapshot_name = None
             summary_output = None
             if success:
+                meta.append("status: Success!")
                 if snapshot_mode == "link-dest":
                     summary_output = ""
                     if base_snapshot:
@@ -351,6 +348,7 @@ class StoragePing:
                                 snapshot["name"]
                             )
             else:
+                meta.append("status: Failed!")
                 summary_output = "rsync exited with return code %d" % returncode
 
             time_end = time.time()
@@ -380,6 +378,10 @@ class StoragePing:
 
         self.logger.info("Done")
         lock.close()
+
+        meta_path = os.path.join(machine_dir, ".turku-storage-metadata.txt")
+        with open(meta_path, "w") as f:
+            f.write("\n".join(meta) + "\n")
 
     def main(self):
         try:

--- a/turku_storage/update_config.py
+++ b/turku_storage/update_config.py
@@ -104,11 +104,12 @@ def main():
             authorized_keys_out += f.read()
     for machine_uuid in api_reply["machines"]:
         machine = api_reply["machines"][machine_uuid]
-        authorized_keys_out += '%s,command="%s %s" %s (%s)\n' % (
+        authorized_keys_out += '%s,command="%s %s" %s (%s %s)\n' % (
             "no-pty,no-agent-forwarding,no-X11-forwarding,no-user-rc",
             config["authorized_keys_command"],
             machine_uuid,
             machine["ssh_public_key"],
+            machine.get("environment_name", ""),
             machine["unit_name"],
         )
 


### PR DESCRIPTION
There can be more environments where they can have same or similar unit names. This includes the environment name to make it easier to tell which unit from which environment.

Also, for each machine directory on disk, we write out metadata info so it's easier to tell what backups the files on disk are for. See https://bugs.launchpad.net/turku/+bug/2004450

Example:

```
ubuntu@juju-86e177-prod-turku-4:~$ cat /media/turku_storage_0-turku_storage/e07b063d-5b36-4acf-9e52-11509491260f/.turku-storage-metadata.txt
unit_name: cassandra-ps5-r2/0
service_name: cassandra
environment_name: stg-ols-cassandra
ubuntu@juju-86e177-prod-turku-4:~$
```